### PR TITLE
Edited some lines for length to fix overfull hboxes 

### DIFF
--- a/R/RQt.R
+++ b/R/RQt.R
@@ -94,11 +94,15 @@ rqt.getAdapterNames <- function(engine){
 #' @return the added script is returned. Usually the return value is not needed, but in case of debugging it may be useful.
 #' @examples
 #' engine1 <- rqt.getEngine()
-#' addedScript <- rqt.addScript(engine1, "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true")
+#' script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\'
+#' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
+#' addedScript <- rqt.addScript(engine1, script)
 #'
 #' \dontrun{
 #' engine1 <- rqt.getEngine()
-#' addedScript <- rqt.addScript(engine1, "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true")
+#' script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\'
+#' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
+#' addedScript <- rqt.addScript(engine1, script)
 #' }
 #'
 #' @export
@@ -131,7 +135,8 @@ rqt.loadProcess <- function(engine, fileName){
 
 #' Returns the process.
 #'
-#' \code{rqt.getProcess} Returns the process that is submitted to the engine either using \code{rqt.addScript} or \code{rqt.loadProcess}.
+#' \code{rqt.getProcess} Returns the process that was submitted to an engine
+#' using \code{rqt.addScript} or \code{rqt.loadProcess}.
 #'
 #' @param engine the engine instance created by \code{rqt.getEngine}
 #' @return the process submitted to the engine

--- a/man/rqt.addScript.Rd
+++ b/man/rqt.addScript.Rd
@@ -22,11 +22,15 @@ the added script is returned. Usually the return value is not needed, but in cas
 }
 \examples{
 engine1 <- rqt.getEngine()
-addedScript <- rqt.addScript(engine1, "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\\\\\' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true")
+script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\\\\\'
+PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
+addedScript <- rqt.addScript(engine1, script)
 
 \dontrun{
 engine1 <- rqt.getEngine()
-addedScript <- rqt.addScript(engine1, "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\\\\\' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true")
+script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\\\\\'
+PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
+addedScript <- rqt.addScript(engine1, script)
 }
 }
 

--- a/man/rqt.getProcess.Rd
+++ b/man/rqt.getProcess.Rd
@@ -13,7 +13,8 @@ rqt.getProcess(engine)
 the process submitted to the engine
 }
 \description{
-\code{rqt.getProcess} Returns the process that is submitted to the engine either using \code{rqt.addScript} or \code{rqt.loadProcess}.
+\code{rqt.getProcess} Returns the process that was submitted to an engine
+using \code{rqt.addScript} or \code{rqt.loadProcess}.
 }
 \examples{
 engine1 <- rqt.getEngine()


### PR DESCRIPTION
@javadch, see the changes I made to the examples in `R/Rqt.R`; because the examples have never worked for me, I don't know if writing the scripts on multiple lines breaks anything or not. You said elsewhere that you could handle Windows newlines, `\r\n`, so as long as that handling is done in a platform-agnostic way I would expect this change to be just fine. Still worth testing before merging.

Should fix #12.
