### PR TITLE
Fixed some formatting issues in XQt procedures

### DIFF
--- a/R/RQt.R
+++ b/R/RQt.R
@@ -52,7 +52,7 @@ rqt.appName <- function(){
 #'
 #' @export
 rqt.getEngine <- function(){
-  getEngineReturnValue <- .jnew("xqt/api/LanguageServicePoint", "RQt, RQt\\inst, inst")
+  getEngineReturnValue <- .jnew("xqt/api/LanguageServicePoint", "RQt, RQt/inst, inst")
   return(getEngineReturnValue)
 }
 
@@ -94,13 +94,13 @@ rqt.getAdapterNames <- function(engine){
 #' @return the added script is returned. Usually the return value is not needed, but in case of debugging it may be useful.
 #' @examples
 #' engine1 <- rqt.getEngine()
-#' script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\'
+#' script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata/'
 #' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
 #' addedScript <- rqt.addScript(engine1, script)
 #'
 #' \dontrun{
 #' engine1 <- rqt.getEngine()
-#' script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\'
+#' script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata/'
 #' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
 #' addedScript <- rqt.addScript(engine1, script)
 #' }

--- a/demo/RQtTest2.R
+++ b/demo/RQtTest2.R
@@ -2,7 +2,7 @@ library(RQt)
 t <- rqt.versionInfo()
 n <- rqt.appName()
 
-cnnString <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\'
+cnnString <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata//'
 PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
 bindingString <- "BIND b1 CONNECTION=cnn1 SCOPE=xdata_10, mydata1"
 st1String <- "SELECT FROM b1.0 INTO var3"

--- a/demo/RQtTest2.R
+++ b/demo/RQtTest2.R
@@ -2,7 +2,7 @@ library(RQt)
 t <- rqt.versionInfo()
 n <- rqt.appName()
 
-cnnString <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata//'
+cnnString <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata/'
 PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
 bindingString <- "BIND b1 CONNECTION=cnn1 SCOPE=xdata_10, mydata1"
 st1String <- "SELECT FROM b1.0 INTO var3"

--- a/inst/extdata/ex1.xqt
+++ b/inst/extdata/ex1.xqt
@@ -1,4 +1,4 @@
-CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true, externalHeader:true
+CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata/' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true, externalHeader:true
 
 BIND b1 CONNECTION=cnn1 SCOPE=data_10_time, fso2014h, xdata_10, mydata1
 

--- a/inst/extdata/ex1.xqt
+++ b/inst/extdata/ex1.xqt
@@ -1,6 +1,6 @@
 CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata/' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true, externalHeader:true
 
-BIND b1 CONNECTION=cnn1 SCOPE=data_10_time, fso2014h, xdata_10, mydata1
+BIND b1 CONNECTION=cnn1 SCOPE=data_10_time, FSO2014H, xdata_10, mydata1
 
 //SELECT FROM b1.1 INTO result1
 // there is an outlier in the data that should be filtered out. The referred field is not in the perspective

--- a/inst/extdata/ex2.xqt
+++ b/inst/extdata/ex2.xqt
@@ -1,5 +1,5 @@
 // The SOURCE_URI is set to be used from inside R during the CHECK process. Change it accordingly if use for other purposes
-CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='RQt\\extdata\\' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true, externalHeader:true
+CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='RQt/extdata/' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true, externalHeader:true
 
 BIND b1 CONNECTION=cnn1 SCOPE=data_10_time, fso2014h, xdata_10, mydata1
 

--- a/inst/extdata/ex2.xqt
+++ b/inst/extdata/ex2.xqt
@@ -1,7 +1,7 @@
 // The SOURCE_URI is set to be used from inside R during the CHECK process. Change it accordingly if use for other purposes
 CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='RQt/extdata/' PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true, externalHeader:true
 
-BIND b1 CONNECTION=cnn1 SCOPE=data_10_time, fso2014h, xdata_10, mydata1
+BIND b1 CONNECTION=cnn1 SCOPE=data_10_time, FSO2014H, xdata_10, mydata1
 
 //SELECT FROM b1.1 INTO result1
 // there is an outlier in the data that should be filtered out. The referred field is not in the perspective

--- a/man/rqt.addScript.Rd
+++ b/man/rqt.addScript.Rd
@@ -22,13 +22,13 @@ the added script is returned. Usually the return value is not needed, but in cas
 }
 \examples{
 engine1 <- rqt.getEngine()
-script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\\\\\'
+script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata/'
 PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
 addedScript <- rqt.addScript(engine1, script)
 
 \dontrun{
 engine1 <- rqt.getEngine()
-script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata\\\\\\\\'
+script <- "CONNECTION cnn1 ADAPTER=CSV SOURCE_URI='extdata/'
 PARAMETERS=delimiter:comma, fileExtension:csv, firstRowIsHeader:true"
 addedScript <- rqt.addScript(engine1, script)
 }


### PR DESCRIPTION
Replaced all double-backslashes to forward-slashes, which XQt now changes to double-backslashes on Windows systems.

Replaced "fso2014h" with "FSO2014H" to work on case-sensitive platforms.

@javadch, please test
